### PR TITLE
Article summary improvement

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,7 @@
       {% if  article.featured_image %}
         <img src="{{ article.featured_image }}">
       {% endif %}
-      <p>{{ article.summary }}</p>
+      <div>{{ article.summary }}</div>
       {% if article.content != article.summary %}
         <br>
         <a class="btn"

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,7 @@
       {% if  article.featured_image %}
         <img src="{{ article.featured_image }}">
       {% endif %}
-      {{ article.summary }}
+      <p>{{ article.summary }}</p>
       {% if article.content != article.summary %}
         <br>
         <a class="btn"


### PR DESCRIPTION
Article summary improvement, in case the summary consist of only 1 line.
This patch takes care that the button "Continue Reading" is shown under the article, instead of against the article.
It will be located at the same location compared to multi-line summaries.

See https://github.com/alexandrevicenzi/Flex/issues/272.
